### PR TITLE
feat(seed): expand development seed with realistic data

### DIFF
--- a/apps/server/drizzle.config.ts
+++ b/apps/server/drizzle.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "drizzle-kit";
 dotenv.config();
 
 export default defineConfig({
-    schema: "./src/auth/auth-schema.ts",
+    schema: ["./src/auth/auth-schema.ts", "./src/db/schema.ts"],
     out: "./drizzle/migrations",
     dialect: "postgresql",
     dbCredentials: {

--- a/apps/server/drizzle/migrations/0001_purple_vermin.sql
+++ b/apps/server/drizzle/migrations/0001_purple_vermin.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "asignaciones" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"vehiculo_id" integer NOT NULL,
+	"conductor_id" text NOT NULL,
+	"status" text NOT NULL,
+	"fecha_asignacion" timestamp with time zone DEFAULT now(),
+	"motivo" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "vehiculos" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"patente" text NOT NULL,
+	"marca" text NOT NULL,
+	"modelo" text NOT NULL,
+	"year" integer NOT NULL,
+	"tipo" text NOT NULL,
+	"proximo_mantenimiento" timestamp with time zone NOT NULL,
+	CONSTRAINT "vehiculos_patente_unique" UNIQUE("patente")
+);
+--> statement-breakpoint
+ALTER TABLE "asignaciones" ADD CONSTRAINT "asignaciones_vehiculo_id_vehiculos_id_fk" FOREIGN KEY ("vehiculo_id") REFERENCES "public"."vehiculos"("id") ON DELETE no action ON UPDATE no action;

--- a/apps/server/drizzle/migrations/meta/0001_snapshot.json
+++ b/apps/server/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,453 @@
+{
+  "id": "6fa0cf2f-f531-404c-b820-eb4db7832654",
+  "prevId": "ca6a72ec-d502-4bd6-a372-e113c0e47b6b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rol": {
+          "name": "rol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONDUCTOR'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asignaciones": {
+      "name": "asignaciones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehiculo_id": {
+          "name": "vehiculo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conductor_id": {
+          "name": "conductor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_asignacion": {
+          "name": "fecha_asignacion",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "motivo": {
+          "name": "motivo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asignaciones_vehiculo_id_vehiculos_id_fk": {
+          "name": "asignaciones_vehiculo_id_vehiculos_id_fk",
+          "tableFrom": "asignaciones",
+          "tableTo": "vehiculos",
+          "columnsFrom": [
+            "vehiculo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehiculos": {
+      "name": "vehiculos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "patente": {
+          "name": "patente",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marca": {
+          "name": "marca",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelo": {
+          "name": "modelo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proximo_mantenimiento": {
+          "name": "proximo_mantenimiento",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehiculos_patente_unique": {
+          "name": "vehiculos_patente_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "patente"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/migrations/meta/_journal.json
+++ b/apps/server/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1749772704325,
       "tag": "0000_fuzzy_mindworm",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1749867896125,
+      "tag": "0001_purple_vermin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -1,6 +1,5 @@
 import { pgTable, serial, text, integer, timestamp } from "drizzle-orm/pg-core";
 
-// Tabla de vehículos
 export const vehiculos = pgTable("vehiculos", {
     id: serial("id").primaryKey(),
     patente: text("patente").notNull().unique(),
@@ -11,7 +10,6 @@ export const vehiculos = pgTable("vehiculos", {
     proximoMantenimiento: timestamp("proximo_mantenimiento", { withTimezone: true }).notNull(),
 });
 
-// Tabla de asignaciones
 export const asignaciones = pgTable("asignaciones", {
     id: serial("id").primaryKey(),
     vehiculoId: integer("vehiculo_id").references(() => vehiculos.id).notNull(),

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -1,28 +1,24 @@
 import { pgTable, serial, text, integer, timestamp } from "drizzle-orm/pg-core";
 
-
+// Tabla de vehículos
 export const vehiculos = pgTable("vehiculos", {
     id: serial("id").primaryKey(),
     patente: text("patente").notNull().unique(),
     marca: text("marca").notNull(),
     modelo: text("modelo").notNull(),
     year: integer("year").notNull(),
-    tipo: text("tipo").notNull(), // Ej: camión, van, etc.
+    tipo: text("tipo").notNull(),
+    proximoMantenimiento: timestamp("proximo_mantenimiento", { withTimezone: true }).notNull(),
 });
 
-
+// Tabla de asignaciones
 export const asignaciones = pgTable("asignaciones", {
     id: serial("id").primaryKey(),
     vehiculoId: integer("vehiculo_id").references(() => vehiculos.id).notNull(),
-    conductor: text("conductor").notNull(),
+    conductorId: text("conductor_id").notNull(), // ID del usuario proporcionado por BetterAuth
+    status: text("status", {
+        enum: ['pendiente', 'en progreso', 'completada', 'cancelada'],
+    }).notNull(),
     fechaAsignacion: timestamp("fecha_asignacion", { withTimezone: true }).defaultNow(),
-});
-
-
-export const mantenimientos = pgTable("mantenimientos", {
-    id: serial("id").primaryKey(),
-    vehiculoId: integer("vehiculo_id").references(() => vehiculos.id).notNull(),
-    descripcion: text("descripcion").notNull(),
-    fecha: timestamp("fecha", { withTimezone: true }).defaultNow(),
-    kilometraje: integer("kilometraje").notNull(),
+    motivo: text("motivo").notNull(),
 });

--- a/apps/server/src/db/seed.ts
+++ b/apps/server/src/db/seed.ts
@@ -1,64 +1,69 @@
-
-import { db } from "./server";
-import { asignaciones, mantenimientos, vehiculos } from "./schema";
+import { db } from "./server.js";
+import { vehiculos, asignaciones } from "./schema.js";
 
 async function resetDB() {
-    await db.delete(asignaciones);
-    await db.delete(mantenimientos);
-    await db.delete(vehiculos);
-    console.log("[RESET] Base de datos reiniciada");
+  await db.delete(asignaciones);
+  await db.delete(vehiculos);
+  console.log("[RESET] Base de datos reiniciada");
 }
 
 async function populateDB() {
-    const vehiculosInsert = await db.insert(vehiculos).values([
+  const insertedVehiculos = await db.insert(vehiculos).values([
     {
-        patente: "ABCD12",
-        marca: "Toyota",
-        modelo: "Hilux",
-        year: 2020,
-        tipo: "camioneta",
+      patente: "JKLT91",
+      marca: "Nissan",
+      modelo: "NP300",
+      year: 2021,
+      tipo: "camioneta",
+      proximoMantenimiento: new Date("2025-06-21T02:12:22.045849"),
     },
     {
-        patente: "EFGH34",
-        marca: "Chevrolet",
-        modelo: "D-Max",
-        year: 2019,
-        tipo: "camion",
+      patente: "GHPL83",
+      marca: "Toyota",
+      modelo: "Hilux",
+      year: 2022,
+      tipo: "pickup",
+      proximoMantenimiento: new Date("2025-06-28T02:12:22.045861"),
     },
-    ]).returning();
+    {
+      patente: "MZQP57",
+      marca: "Chevrolet",
+      modelo: "D-Max",
+      year: 2020,
+      tipo: "camion",
+      proximoMantenimiento: new Date("2025-07-14T02:12:22.045864"),
+    }
+  ]).returning();
 
-    await db.insert(asignaciones).values([
+  await db.insert(asignaciones).values([
     {
-        vehiculoId: vehiculosInsert[0].id,
-        conductor: "Juan Pérez",
+      vehiculoId: insertedVehiculos[0].id,
+      conductorId: "user_conductor1",
+      status: "pendiente",
+      motivo: "Entrega zona norte",
     },
     {
-        vehiculoId: vehiculosInsert[1].id,
-        conductor: "Ana Gómez",
+      vehiculoId: insertedVehiculos[1].id,
+      conductorId: "user_conductor2",
+      status: "en progreso",
+      motivo: "Reparto en ruta sur",
     },
-    ]);
+    {
+      vehiculoId: insertedVehiculos[2].id,
+      conductorId: "user_conductor3",
+      status: "completada",
+      motivo: "Logística interurbana",
+    }
+  ]);
 
-    await db.insert(mantenimientos).values([
-    {
-        vehiculoId: vehiculosInsert[0].id,
-        descripcion: "Cambio de aceite",
-        kilometraje: 12000,
-    },
-    {
-        vehiculoId: vehiculosInsert[1].id,
-        descripcion: "Revisión general",
-        kilometraje: 8000,
-    },
-    ]);
-
-    console.log("[SEED] Datos de ejemplo insertados");
+  console.log("[SEED] Datos insertados correctamente");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-    const action = process.argv[2];
-    if (action === "reset") resetDB();
-    else if (action === "populate") populateDB();
-    else console.log("Usa: tsx src/db/seed.ts [reset|populate]");
+  const action = process.argv[2];
+  if (action === "reset") resetDB();
+  else if (action === "populate") populateDB();
+  else console.log("Usa: tsx src/db/seed.ts [reset|populate]");
 }
 
 export { resetDB, populateDB };


### PR DESCRIPTION
Enhanced seed.ts to include multiple entries for development testing:

- Added 3 vehicles with distinct attributes and future maintenance dates.
- Created 3 realistic assignments using simulated BetterAuth user IDs.
- Covered various assignment statuses: pendiente, en progreso, completada.
- Ensured seed remains idempotent and usable via CLI for fast resets.

Improves frontend testing, state variation, and data-driven UI validation."