### PR TITLE
🔒 CRUD protegido para vehículos y asignaciones (solo admin)

### DIFF
--- a/apps/server/src/routes/asignacionesadmin.ts
+++ b/apps/server/src/routes/asignacionesadmin.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { router } from '../trpc/core';
+import { adminProcedure } from '../trpc/procedures';
+import { asignaciones } from '../db/schema';
+import { db } from '../db/server';
+import { eq } from 'drizzle-orm';
+
+// Esquema corregido según los campos reales
+const asignacionSchema = z.object({
+  fechaAsignacion: z.string().refine(val => !isNaN(Date.parse(val)), {
+    message: 'Fecha inválida',
+  }),
+  vehiculoId: z.number().int(),
+  conductorId: z.string(),
+  motivo: z.string().max(100),
+  status: z.string().max(20),
+});
+
+const asignacionUpdateSchema = asignacionSchema.extend({
+  id: z.number().int(),
+});
+
+const asignacionDeleteSchema = z.object({
+  id: z.number().int(),
+});
+
+export const asignacionesAdminRouter = router({
+  getAll: adminProcedure.query(async () => {
+    return await db.select().from(asignaciones);
+  }),
+
+  create: adminProcedure
+    .input(asignacionSchema)
+    .mutation(async ({ input }: { input: z.infer<typeof asignacionSchema> }) => {
+      const result = await db.insert(asignaciones).values({
+        ...input,
+        fechaAsignacion: new Date(input.fechaAsignacion),
+      }).returning();
+      return { message: 'Asignación creada exitosamente', data: result[0] };
+    }),
+
+  update: adminProcedure
+    .input(asignacionUpdateSchema)
+    .mutation(async ({ input }: { input: z.infer<typeof asignacionUpdateSchema> }) => {
+      const { id, ...data } = input;
+      const result = await db
+        .update(asignaciones)
+        .set({
+          ...data,
+          fechaAsignacion: new Date(data.fechaAsignacion),
+        })
+        .where(eq(asignaciones.id, id))
+        .returning();
+      return { message: 'Asignación actualizada exitosamente', data: result[0] };
+    }),
+
+  delete: adminProcedure
+    .input(asignacionDeleteSchema)
+    .mutation(async ({ input }: { input: z.infer<typeof asignacionDeleteSchema> }) => {
+      await db.delete(asignaciones).where(eq(asignaciones.id, input.id));
+      return { message: 'Asignación eliminada exitosamente' };
+    }),
+});

--- a/apps/server/src/routes/vehiculosadmin.ts
+++ b/apps/server/src/routes/vehiculosadmin.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+import { router } from '../trpc/core';
+import { adminProcedure } from '../trpc/procedures'; // <- CORREGIDO
+import { vehiculos } from '../db/schema';
+import { db } from '../db/server';
+import { eq } from 'drizzle-orm';
+
+// Esquema base para crear vehículos
+const vehiculoSchema = z.object({
+  patente: z.string().max(10),
+  marca: z.string().max(50),
+  modelo: z.string().max(50),
+  year: z.number().int(),
+  tipo: z.string().max(50),
+  proximoMantenimiento: z.string().refine(
+    (val) => !isNaN(Date.parse(val)),
+    { message: 'Fecha inválida' }
+  ),
+});
+
+// Para actualizar: incluye ID
+const vehiculoUpdateSchema = vehiculoSchema.extend({
+  id: z.number().int(),
+});
+
+// Para eliminar: solo ID
+const vehiculoDeleteSchema = z.object({
+  id: z.number().int(),
+});
+
+export const vehiculosAdminRouter = router({
+  // Obtener todos los vehículos (solo admin)
+  getAll: adminProcedure.query(async () => {
+    return await db.select().from(vehiculos);
+  }),
+
+  // Crear un nuevo vehículo
+  create: adminProcedure
+    .input(vehiculoSchema)
+    .mutation(async ({ input }: { input: z.infer<typeof vehiculoSchema> }) => {
+      const result = await db.insert(vehiculos).values({
+        ...input,
+        proximoMantenimiento: new Date(input.proximoMantenimiento),
+      }).returning();
+      return { message: 'Vehículo creado exitosamente', data: result[0] };
+    }),
+
+  // Actualizar un vehículo existente
+  update: adminProcedure
+    .input(vehiculoUpdateSchema)
+    .mutation(async ({ input }: { input: z.infer<typeof vehiculoUpdateSchema> }) => {
+      const { id, ...data } = input;
+      const result = await db
+        .update(vehiculos)
+        .set({
+          ...data,
+          proximoMantenimiento: new Date(data.proximoMantenimiento),
+        })
+        .where(eq(vehiculos.id, id))
+        .returning();
+      return { message: 'Vehículo actualizado exitosamente', data: result[0] };
+    }),
+
+  // Eliminar un vehículo
+  delete: adminProcedure
+    .input(vehiculoDeleteSchema)
+    .mutation(async ({ input }: { input: z.infer<typeof vehiculoDeleteSchema> }) => {
+      try {
+        await db.delete(vehiculos).where(eq(vehiculos.id, input.id));
+        return { message: 'Vehículo eliminado exitosamente' };
+      } catch (error) {
+        console.error('Error al eliminar vehículo:', error);
+        throw new Error('No se pudo eliminar el vehículo. Verifica si tiene asignaciones activas.');
+      }
+    }),
+});

--- a/apps/server/src/trpc/root.ts
+++ b/apps/server/src/trpc/root.ts
@@ -3,7 +3,7 @@ import { protectedProcedure, adminProcedure } from './procedures';
 import { vehiculoRouter } from '../routes/vehiculos';
 import { asignacionRouter } from '../routes/asignaciones';
 import { vehiculosAdminRouter } from '../routes/vehiculosadmin';
-
+import { asignacionesAdminRouter } from '../routes/asignacionesadmin';
 
 export const appRouter = router({
   perfil: protectedProcedure.query(({ ctx }) => ctx.user),
@@ -11,6 +11,7 @@ export const appRouter = router({
   vehiculos: vehiculoRouter,
   asignaciones: asignacionRouter,
   vehiculosadmin: vehiculosAdminRouter,
+  asignacionesadmin: asignacionesAdminRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/server/src/trpc/root.ts
+++ b/apps/server/src/trpc/root.ts
@@ -2,12 +2,15 @@ import { router } from './core';
 import { protectedProcedure, adminProcedure } from './procedures';
 import { vehiculoRouter } from '../routes/vehiculos';
 import { asignacionRouter } from '../routes/asignaciones';
+import { vehiculosAdminRouter } from '../routes/vehiculosadmin';
+
 
 export const appRouter = router({
   perfil: protectedProcedure.query(({ ctx }) => ctx.user),
   admin: adminProcedure.query(() => 'solo admins'),
   vehiculos: vehiculoRouter,
   asignaciones: asignacionRouter,
+  vehiculosadmin: vehiculosAdminRouter,
 });
 
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
Complete CRUD endpoints were implemented and tested for the entities `vehiculos` and `asignaciones`, focusing on administrator management. Initially, `publicProcedure` was used to facilitate testing in Bruno, and then secured with `adminProcedure` accordingly.

- `vehiculosadmin.ts`: Full CRUD using `adminProcedure`
- `asignacionesadmin.ts`: Full CRUD using `adminProcedure`
- Strict validations with Zod for all inputs
- Date handling correctly converted to `Date` in the database layer
- Structure compatible with TRPC + Hono
- Successful functional testing in the local environment with and without a token

All endpoints are restricted to authenticated users with `role: "ADMIN"`.
