### PR TITLE
feat(conductor): mejora el flujo de cambio de estado y registro de kilometraje en asignaciones

### DIFF
--- a/apps/frontend/src/components/conductor/assignments/assignment-card.tsx
+++ b/apps/frontend/src/components/conductor/assignments/assignment-card.tsx
@@ -1,23 +1,13 @@
 "use client";
 import { Badge } from "@/components/ui/badge";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { useTRPC } from "@/lib/trpc";
-import type { Asignaciones } from "@/types";
-import { useMutation } from "@tanstack/react-query";
-import {
-  ChevronDown,
   Clock,
   Play,
   CheckCircle,
   XCircle,
   type LucideIcon,
 } from "lucide-react";
-import { toast } from "sonner";
+import type { Asignaciones } from "@/types";
 
 const estadoConfig: {
   [key in Asignaciones["status"]]: {
@@ -50,36 +40,20 @@ const estadoConfig: {
 
 interface Props {
   assignment: Asignaciones;
+  disabled?: boolean;
+  onClick?: () => void;
 }
 
-export const AssignmentsCard = ({ assignment }: Props) => {
-  const trpc = useTRPC();
-  const updateStatusMutation = useMutation(
-    trpc.asignaciones.updateStatus.mutationOptions()
-  );
-
-  const handleStatusChange = (newStatus: Asignaciones["status"]) => {
-    try {
-      updateStatusMutation.mutate({
-        id: assignment.id,
-        status: newStatus as
-          | "pendiente"
-          | "en progreso"
-          | "completada"
-          | "cancelada",
-      });
-      toast.success("Estado de asignación actualizado");
-    } catch (error) {
-      console.error("Error al actualizar estado de asignación:", error);
-      toast.error("Error al actualizar estado de asignación");
-    }
-  };
-
+export const AssignmentsCard = ({ assignment, disabled = false, onClick }: Props) => {
   const currentConfig = estadoConfig[assignment.status];
   const CurrentIcon = currentConfig.icon;
 
   return (
-    <div className="flex flex-col md:flex-row justify-between gap-2 p-3 border rounded-lg">
+    <div
+      className={`flex flex-col md:flex-row justify-between gap-2 p-3 border rounded-lg transition-opacity ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+      onClick={!disabled ? onClick : undefined}
+      tabIndex={disabled ? -1 : 0}
+    >
       <div>
         <div className="font-medium">
           {assignment.vehiculo?.patente} - {assignment.motivo}
@@ -92,34 +66,12 @@ export const AssignmentsCard = ({ assignment }: Props) => {
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Badge
-              className={`cursor-pointer transition-colors capitalize ${currentConfig.color} flex items-center gap-1`}
-            >
-              <CurrentIcon className="h-3 w-3" />
-              {currentConfig.label}
-              <ChevronDown className="h-3 w-3" />
-            </Badge>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {Object.entries(estadoConfig).map(([estado, config]) => {
-              const Icon = config.icon;
-              return (
-                <DropdownMenuItem
-                  key={estado}
-                  onClick={() =>
-                    handleStatusChange(estado as Asignaciones["status"])
-                  }
-                  className="flex items-center gap-2"
-                >
-                  <Icon className="h-4 w-4" />
-                  {config.label}
-                </DropdownMenuItem>
-              );
-            })}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <Badge
+          className={`capitalize ${currentConfig.color} flex items-center gap-1`}
+        >
+          <CurrentIcon className="h-3 w-3" />
+          {currentConfig.label}
+        </Badge>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/conductor/assignments/assignment-card.tsx
+++ b/apps/frontend/src/components/conductor/assignments/assignment-card.tsx
@@ -1,13 +1,23 @@
 "use client";
 import { Badge } from "@/components/ui/badge";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useTRPC } from "@/lib/trpc";
+import type { Asignaciones } from "@/types";
+import { useMutation } from "@tanstack/react-query";
+import {
+  ChevronDown,
   Clock,
   Play,
   CheckCircle,
   XCircle,
   type LucideIcon,
 } from "lucide-react";
-import type { Asignaciones } from "@/types";
+import { toast } from "sonner";
 
 const estadoConfig: {
   [key in Asignaciones["status"]]: {
@@ -40,20 +50,36 @@ const estadoConfig: {
 
 interface Props {
   assignment: Asignaciones;
-  disabled?: boolean;
-  onClick?: () => void;
 }
 
-export const AssignmentsCard = ({ assignment, disabled = false, onClick }: Props) => {
+export const AssignmentsCard = ({ assignment }: Props) => {
+  const trpc = useTRPC();
+  const updateStatusMutation = useMutation(
+    trpc.asignaciones.updateStatus.mutationOptions()
+  );
+
+  const handleStatusChange = (newStatus: Asignaciones["status"]) => {
+    try {
+      updateStatusMutation.mutate({
+        id: assignment.id,
+        status: newStatus as
+          | "pendiente"
+          | "en progreso"
+          | "completada"
+          | "cancelada",
+      });
+      toast.success("Estado de asignación actualizado");
+    } catch (error) {
+      console.error("Error al actualizar estado de asignación:", error);
+      toast.error("Error al actualizar estado de asignación");
+    }
+  };
+
   const currentConfig = estadoConfig[assignment.status];
   const CurrentIcon = currentConfig.icon;
 
   return (
-    <div
-      className={`flex flex-col md:flex-row justify-between gap-2 p-3 border rounded-lg transition-opacity ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
-      onClick={!disabled ? onClick : undefined}
-      tabIndex={disabled ? -1 : 0}
-    >
+    <div className="flex flex-col md:flex-row justify-between gap-2 p-3 border rounded-lg">
       <div>
         <div className="font-medium">
           {assignment.vehiculo?.patente} - {assignment.motivo}
@@ -66,12 +92,34 @@ export const AssignmentsCard = ({ assignment, disabled = false, onClick }: Props
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <Badge
-          className={`capitalize ${currentConfig.color} flex items-center gap-1`}
-        >
-          <CurrentIcon className="h-3 w-3" />
-          {currentConfig.label}
-        </Badge>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Badge
+              className={`cursor-pointer transition-colors capitalize ${currentConfig.color} flex items-center gap-1`}
+            >
+              <CurrentIcon className="h-3 w-3" />
+              {currentConfig.label}
+              <ChevronDown className="h-3 w-3" />
+            </Badge>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {Object.entries(estadoConfig).map(([estado, config]) => {
+              const Icon = config.icon;
+              return (
+                <DropdownMenuItem
+                  key={estado}
+                  onClick={() =>
+                    handleStatusChange(estado as Asignaciones["status"])
+                  }
+                  className="flex items-center gap-2"
+                >
+                  <Icon className="h-4 w-4" />
+                  {config.label}
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/dashboard/forms/register-kilometraje.tsx
+++ b/apps/frontend/src/components/dashboard/forms/register-kilometraje.tsx
@@ -1,0 +1,154 @@
+
+import React from "react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useTRPC } from "@/lib/trpc";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Loader2 } from "lucide-react";
+
+// Esquema Zod: solo el campo de kilometraje
+const formSchema = z.object({
+  kilometraje: z
+    .number({ invalid_type_error: "Debe ingresar un número" })
+    .min(0, { message: "El kilometraje debe ser positivo" }),
+});
+
+type RegisterKilometrajeValues = z.infer<typeof formSchema>;
+
+// Definición del tipo Vehiculo según lo retornado por TRPC
+interface Vehiculo {
+  id: number;
+  patente: string;
+  marca: string;
+  modelo: string;
+  year: number;
+  tipo: string;
+  kilometraje?: number;
+  fueraServicio?: boolean;
+  // Fecha de próximo mantenimiento, si está disponible
+  proximoMantenimiento?: Date;
+}
+
+interface RegisterKilometrajeProps {
+  asignacionId: number;
+  vehiculo: Vehiculo;
+  onSuccess: () => void;
+}
+
+export const RegisterKilometraje = (
+  { asignacionId, vehiculo, onSuccess }: RegisterKilometrajeProps
+): React.ReactElement => {
+  const trpc = useTRPC();
+  // Mutaciones TRPC existentes: actualizar vehículo y estado de asignación
+  const updateVehicleMutation = useMutation(
+    trpc.vehiculos.updateById.mutationOptions()
+  );
+  const updateStatusMutation = useMutation(
+    trpc.asignaciones.updateStatus.mutationOptions()
+  );
+
+  // React Hook Form con Zod
+  const form = useForm<RegisterKilometrajeValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { kilometraje: vehiculo.kilometraje ?? 0 },
+  });
+
+  // Al enviar: primero actualizar vehículo, luego estado de asignación
+  const onSubmit = (values: RegisterKilometrajeValues) => {
+    // Desestructuramos campos base del vehículo
+    const { patente, marca, modelo, year, tipo } = vehiculo;
+    const fueraServicio = vehiculo.fueraServicio ?? false;
+    // Aseguramos un valor para proximoMantenimiento (requerido por el servidor)
+    const proximoMantenimiento =
+      vehiculo.proximoMantenimiento ?? new Date();
+
+    // Preparamos el objeto con todas las propiedades necesarias
+    const vehiculoData = {
+      patente,
+      marca,
+      modelo,
+      year,
+      tipo,
+      kilometraje: values.kilometraje,
+      fueraServicio,
+      proximoMantenimiento,
+    };
+
+    updateVehicleMutation.mutate(
+      { id: vehiculo.id, data: vehiculoData },
+      {
+        onError(error) {
+          toast.error(`Error al actualizar vehículo: ${error.message}`);
+        },
+        onSuccess() {
+          updateStatusMutation.mutate(
+            { id: asignacionId, status: "completada" },
+            {
+              onError(error) {
+                toast.error(
+                  `Error al actualizar asignación: ${error.message}`
+                );
+              },
+              onSuccess() {
+                toast.success(
+                  "Kilometraje registrado y asignación completada"
+                );
+                onSuccess();
+              },
+            }
+          );
+        },
+      }
+    );
+  };
+
+  const isSubmitting =
+    updateVehicleMutation.isPending || updateStatusMutation.isPending;
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        {/* Campo kilometraje */}
+        <FormField
+          control={form.control}
+          name="kilometraje"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Kilometraje</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="Ingresa kilometraje actual"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Botón de envío */}
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {isSubmitting ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            "Guardar"
+          )}
+        </Button>
+      </form>
+    </Form>
+  );
+};
+

--- a/apps/frontend/src/routes/conductor/index.tsx
+++ b/apps/frontend/src/routes/conductor/index.tsx
@@ -46,7 +46,8 @@ export function RouteComponent() {
             ...veh,
             kilometraje: veh.kilometraje ?? 0,
             fueraServicio: veh.fueraServicio ?? false,
-            proximoMantenimiento: veh.proximoMantenimiento ?? new Date(),
+            proximoMantenimiento:
+              veh.proximoMantenimiento ?? new Date(),
           }
         : null,
     } as Asignaciones;
@@ -77,6 +78,7 @@ export function RouteComponent() {
   // Inicializar el select cuando abrimos el modal
   useEffect(() => {
     if (selected) {
+      // select valor ya está garantizado como Status
       setNewStatus(selected.status as Status);
     }
   }, [selected]);
@@ -106,30 +108,23 @@ export function RouteComponent() {
     (a) => a.status.toLowerCase() === "completada"
   );
 
-  // Solo permite abrir el modal si la asignación NO está completada
-  const handleCardClick = (a: Asignaciones) => {
-    if (a.status.toLowerCase() !== "completada") {
-      setSelected(a);
-    }
-  };
-
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
         <div className="md:col-span-2 space-y-4">
           {normales.map((a) => (
-            <AssignmentsCard
+            <div
               key={a.id}
-              assignment={a}
-              onClick={() => handleCardClick(a)}
-            />
+              className="cursor-pointer"
+              onClick={() => setSelected(a)}
+            >
+              <AssignmentsCard assignment={a} />
+            </div>
           ))}
           {completadas.map((a) => (
-            <AssignmentsCard
-              key={a.id}
-              assignment={a}
-              disabled
-            />
+            <div key={a.id} className="opacity-50">
+              <AssignmentsCard assignment={a} />
+            </div>
           ))}
         </div>
         <div>
@@ -147,66 +142,65 @@ export function RouteComponent() {
           <DialogHeader>
             <DialogTitle>Actualizar Asignación</DialogTitle>
             <DialogDescription>
-              Selecciona un nuevo estado. Si eliges "Completada", ingresa el kilometraje a continuación.
+              Selecciona un nuevo estado. Si eliges "Completada", ingresa el
+              kilometraje a continuación.
             </DialogDescription>
           </DialogHeader>
 
           {loadingVeh ? (
             <div>Cargando datos del vehículo…</div>
           ) : selected && fullVehiculo ? (
-            selected.status === "completada" ? (
-              <div className="text-center text-muted-foreground">
-                Esta asignación ya fue completada y no puede ser modificada.
+            <>
+              {/* Selector de estado */}
+              <div className="space-y-4">
+                <label htmlFor="status" className="block text-sm font-medium">
+                  Estado
+                </label>
+                <select
+                  id="status"
+                  value={newStatus}
+                  onChange={(e) =>
+                    setNewStatus(e.target.value as Status)
+                  }
+                  disabled={selected.status.toLowerCase() === "completada"}
+                  className="mt-1 block w-full"
+                >
+                  <option value="pendiente">Pendiente</option>
+                  <option value="en progreso">En Progreso</option>
+                  <option value="completada">Completada</option>
+                  <option value="cancelada">Cancelada</option>
+                </select>
               </div>
-            ) : (
-              <>
-                <div className="space-y-4">
-                  <label htmlFor="status" className="block text-sm font-medium">
-                    Estado
-                  </label>
-                  <select
-                    id="status"
-                    value={newStatus}
-                    onChange={(e) =>
-                      setNewStatus(e.target.value as Status)
-                    }
-                    className="mt-1 block w-full"
-                  >
-                    <option value="pendiente">Pendiente</option>
-                    <option value="en progreso">En Progreso</option>
-                    <option value="completada">Completada</option>
-                    <option value="cancelada">Cancelada</option>
-                  </select>
-                </div>
 
-                {newStatus === "completada" ? (
-                  <RegisterKilometraje
-                    asignacionId={selected.id}
-                    vehiculo={{
-                      ...fullVehiculo,
-                      proximoMantenimiento: (
-                        selected.vehiculo as any
-                      ).proximoMantenimiento,
-                    } as any}
-                    onSuccess={() => {
-                      queryClient.invalidateQueries({
-                        queryKey: assignmentOptions.queryKey,
-                      });
-                      setSelected(null);
-                    }}
-                  />
-                ) : (
-                  <DialogFooter>
-                    <button
-                      onClick={handleSaveStatus}
-                      className="inline-flex justify-center rounded-md border px-4 py-2 text-sm font-medium"
-                    >
-                      Guardar
-                    </button>
-                  </DialogFooter>
-                )}
-              </>
-            )
+              {newStatus === "completada" ? (
+                // Flujo completa + kilómetro
+                <RegisterKilometraje
+                  asignacionId={selected.id}
+                  vehiculo={{
+                    ...fullVehiculo,
+                    proximoMantenimiento: (
+                      selected.vehiculo as any
+                    ).proximoMantenimiento,
+                  } as any}
+                  onSuccess={() => {
+                    queryClient.invalidateQueries({
+                      queryKey: assignmentOptions.queryKey,
+                    });
+                    setSelected(null);
+                  }}
+                />
+              ) : (
+                // Botón para guardar estados no completados
+                <DialogFooter>
+                  <button
+                    onClick={handleSaveStatus}
+                    className="inline-flex justify-center rounded-md border px-4 py-2 text-sm font-medium"
+                  >
+                    Guardar
+                  </button>
+                </DialogFooter>
+              )}
+            </>
           ) : (
             <div className="p-4 text-center">
               Selecciona primero una asignación.

--- a/apps/frontend/src/routes/conductor/index.tsx
+++ b/apps/frontend/src/routes/conductor/index.tsx
@@ -1,44 +1,142 @@
-import { RecentAssignments } from "@/components/conductor/assignments";
-import { MaintenanceAlerts } from "@/components/conductor/maintenance-alerts";
+
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
 import { useSession } from "@/lib/auth-client";
 import { useTRPC } from "@/lib/trpc";
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { AssignmentsCard } from "@/components/conductor/assignments/assignment-card";
+import { MaintenanceAlerts } from "@/components/conductor/maintenance-alerts";
+import { RegisterKilometraje } from "@/components/dashboard/forms/register-kilometraje";
+import type { Asignaciones } from "@/types";
 
 export const Route = createFileRoute("/conductor/")({
   component: RouteComponent,
 });
 
-function RouteComponent() {
+export function RouteComponent() {
   const { data: session } = useSession();
   const trpc = useTRPC();
 
-  const { data, isLoading } = useQuery(
-    trpc.asignaciones.getByConductorId.queryOptions({
-      conductorId: session?.user.id ?? "",
-    })
+  // 1) Obtener asignaciones crudas
+  const assignmentOptions = trpc.asignaciones.getByConductorId.queryOptions({
+    conductorId: session?.user.id ?? "",
+  });
+  const {
+    data: rawAssignments,
+    isLoading: loadingAsig,
+  } = useQuery({
+    ...assignmentOptions,
+    enabled: Boolean(session?.user.id),
+  });
+
+  // 2) Normalizar vehiculo para cumplir con el tipo Asignaciones
+  const assignments: Asignaciones[] = (rawAssignments ?? []).map((a) => ({
+    ...a,
+    vehiculo: a.vehiculo
+      ? {
+          ...a.vehiculo,
+          kilometraje: (a.vehiculo as any).kilometraje ?? 0,
+          fueraServicio: (a.vehiculo as any).fueraServicio ?? false,
+        }
+      : null,
+  }));
+
+  const [selected, setSelected] = useState<Asignaciones | null>(null);
+
+  // 3) Obtener datos completos del vehículo al seleccionar
+  const vehicleOptions = trpc.vehiculos.getById.queryOptions({
+    id: selected?.vehiculo?.id ?? 0,
+  });
+  const {
+    data: fullVehiculo,
+    isLoading: loadingVeh,
+  } = useQuery({
+    ...vehicleOptions,
+    enabled: selected !== null,
+  });
+
+  if (loadingAsig) {
+    return <div>Cargando asignaciones…</div>;
+  }
+
+  // 4) Filtrar asignaciones según estado y motivo
+  const normales = assignments.filter(
+    (a) =>
+      !a.motivo.toLowerCase().includes("mantenimiento") &&
+      a.status.toLowerCase() !== "completada"
   );
-
-  if (isLoading) return <div>Cargando...</div>;
-
-  const mantenimientos = data?.filter(
+  const mantenimientos = assignments.filter(
     (a) =>
       a.motivo.toLowerCase().includes("mantenimiento") &&
       a.status.toLowerCase() !== "completada"
   );
 
-  const asignaciones = data?.filter(
-    (a) => !a.motivo.toLowerCase().includes("mantenimiento")
-  );
-
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-      <div className="md:col-span-2">
-        <RecentAssignments assignments={asignaciones ?? []} />
+    <>
+      {/* Listado de asignaciones normales */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        <div className="md:col-span-2 space-y-4">
+          {normales.map((a) => (
+            <div
+              key={a.id}
+              className="cursor-pointer"
+              onClick={() => setSelected(a)}
+            >
+              <AssignmentsCard assignment={a} />
+            </div>
+          ))}
+          {/* Mostrar asignaciones completadas sin acción */}
+          {assignments
+            .filter((a) => a.status.toLowerCase() === "completada")
+            .map((a) => (
+              <div key={a.id} className="opacity-50">
+                <AssignmentsCard assignment={a} />
+              </div>
+            ))}
+        </div>
+        <div>
+          <MaintenanceAlerts assignments={mantenimientos} />
+        </div>
       </div>
-      <div>
-        <MaintenanceAlerts assignments={mantenimientos ?? []} />
-      </div>
-    </div>
+
+      {/* Modal para registrar kilometraje */}
+      <Dialog
+        open={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Registrar Kilometraje</DialogTitle>
+            <DialogDescription>
+              Ingresa el nuevo kilometraje del vehículo para completar la asignación.
+            </DialogDescription>
+          </DialogHeader>
+
+          {loadingVeh ? (
+            <div>Cargando datos del vehículo…</div>
+          ) : selected && fullVehiculo ? (
+            <RegisterKilometraje
+              asignacionId={selected.id}
+              vehiculo={fullVehiculo}
+              onSuccess={() => setSelected(null)}
+            />
+          ) : (
+            <div className="p-4 text-center">
+              Selecciona primero una asignación para marcar.
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
+

--- a/apps/server/src/routes/vehiculos.ts
+++ b/apps/server/src/routes/vehiculos.ts
@@ -15,7 +15,11 @@ const VehiculoInput = z.object({
     .min(1900)
     .max(new Date().getFullYear() + 1),
   tipo: z.string().min(3),
-  proximoMantenimiento: z.date(),
+  // <-- Cambio: preprocesar string→Date antes de validar
+  proximoMantenimiento: z.preprocess(
+    (val) => (typeof val === "string" ? new Date(val) : val),
+    z.date()
+  ),
   kilometraje: z.number().min(0).default(0),
   fueraServicio: z.boolean().default(false),
 });


### PR DESCRIPTION
Descripción

Este PR implementa y corrige varias mejoras en el flujo de actualización de estado para las asignaciones del conductor:

    Permite registrar el kilometraje solo cuando se marca una asignación como "Completada". El cambio de estado no es efectivo hasta ingresar el nuevo kilometraje.

    Refactoriza el flujo de actualización: elimina el dropdown de cambio de estado desde la card y lo traslada completamente al modal, garantizando validación y coherencia.

    Mejora la experiencia de usuario: ahora las asignaciones completadas aparecen deshabilitadas y no pueden ser modificadas ni abiertas.

    Corrige el manejo de fechas y validación de formularios para el registro de kilometraje.

    Reestructura y limpia la lógica de interacción para asegurar que todos los estados y datos relevantes se manejen desde el modal.

Estos cambios fortalecen la integridad de los datos y mejoran la usabilidad y claridad del módulo de conductor.