### PR TITLE
feat(api): mejora en manejo de errores con tryCatch y TRPCError

### DIFF
--- a/apps/server/src/routes/asignaciones.ts
+++ b/apps/server/src/routes/asignaciones.ts
@@ -1,3 +1,20 @@
+// tryCatch helper
+type Success<T> = { data: T; error: null };
+type Failure<E> = { data: null; error: E };
+type Result<T, E = Error> = Success<T> | Failure<E>;
+
+export async function tryCatch<T, E = Error>(
+  promise: Promise<T>,
+): Promise<Result<T, E>> {
+  try {
+    const data = await promise;
+    return { data, error: null };
+  } catch (error) {
+    return { data: null, error: error as E };
+  }
+}
+
+// --- El resto de tu router ---
 import { db } from "../db/server";
 import { asignaciones } from "../db/schema";
 import { z } from "zod";
@@ -24,81 +41,40 @@ const AsignacionInput = z.object({
 
 export const asignacionRouter = router({
   create: publicProcedure.input(AsignacionInput).mutation(async ({ input }) => {
-    const [vehiculo] = await db
-      .select()
-      .from(vehiculos)
-      .where(eq(vehiculos.id, input.vehiculoId));
-
-    if (!vehiculo) {
+    // Buscar vehículo
+    const { data: vehiculo, error: vehiculoError } = await tryCatch(
+      db.select().from(vehiculos).where(eq(vehiculos.id, input.vehiculoId))
+    );
+    if (vehiculoError) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Error buscando el vehículo en la base de datos",
+      });
+    }
+    if (!vehiculo || vehiculo.length === 0) {
       throw new TRPCError({
         code: "BAD_REQUEST",
         message: `El vehículo con ID ${input.vehiculoId} no existe`,
       });
     }
 
-    const [nuevaAsignacion] = await db
-      .insert(asignaciones)
-      .values(input)
-      .returning();
+    // Insertar nueva asignación
+    const { data: nuevaAsignacion, error: insertError } = await tryCatch(
+      db.insert(asignaciones).values(input).returning()
+    );
+    if (insertError) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "No se pudo crear la asignación",
+      });
+    }
 
-    return nuevaAsignacion;
+    return nuevaAsignacion[0];
   }),
 
   getAll: publicProcedure.query(async () => {
-    const rows = await db
-      .select({
-        id: asignaciones.id,
-        status: asignaciones.status,
-        motivo: asignaciones.motivo,
-        fechaAsignacion: asignaciones.fechaAsignacion,
-        vehiculo: {
-          id: vehiculos.id,
-          patente: vehiculos.patente,
-          marca: vehiculos.marca,
-          modelo: vehiculos.modelo,
-          year: vehiculos.year,
-          tipo: vehiculos.tipo,
-          kilometraje: vehiculos.kilometraje,
-          fueraServicio: vehiculos.fueraServicio,
-        },
-        conductor: {
-          id: user.id,
-          name: user.name,
-          email: user.email,
-          emailVerified: user.emailVerified,
-          image: user.image,
-          role: user.role,
-        },
-      })
-      .from(asignaciones)
-      .leftJoin(vehiculos, eq(asignaciones.vehiculoId, vehiculos.id))
-      .leftJoin(user, eq(asignaciones.conductorId, user.id));
-
-    return rows;
-  }),
-
-  getById: publicProcedure
-    .input(z.object({ id: z.number() }))
-    .query(async ({ input }) => {
-      const [asignacion] = await db
-        .select()
-        .from(asignaciones)
-        .where(eq(asignaciones.id, input.id))
-        .limit(1);
-
-      if (!asignacion) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Asignación no encontrada",
-        });
-      }
-      return asignacion;
-    }),
-
-  getByConductorId: publicProcedure
-    .input(z.object({ conductorId: z.string().min(1) }))
-    .query(async ({ input }) => {
-      return await db
+    const { data: rows, error } = await tryCatch(
+      db
         .select({
           id: asignaciones.id,
           status: asignaciones.status,
@@ -111,6 +87,8 @@ export const asignacionRouter = router({
             modelo: vehiculos.modelo,
             year: vehiculos.year,
             tipo: vehiculos.tipo,
+            kilometraje: vehiculos.kilometraje,
+            fueraServicio: vehiculos.fueraServicio,
           },
           conductor: {
             id: user.id,
@@ -124,7 +102,80 @@ export const asignacionRouter = router({
         .from(asignaciones)
         .leftJoin(vehiculos, eq(asignaciones.vehiculoId, vehiculos.id))
         .leftJoin(user, eq(asignaciones.conductorId, user.id))
-        .where(eq(asignaciones.conductorId, input.conductorId));
+    );
+    if (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Error obteniendo asignaciones",
+      });
+    }
+    return rows;
+  }),
+
+  getById: publicProcedure
+    .input(z.object({ id: z.number() }))
+    .query(async ({ input }) => {
+      const { data: asignacion, error } = await tryCatch(
+        db
+          .select()
+          .from(asignaciones)
+          .where(eq(asignaciones.id, input.id))
+          .limit(1)
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Error obteniendo la asignación",
+        });
+      }
+      if (!asignacion || asignacion.length === 0) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Asignación no encontrada",
+        });
+      }
+      return asignacion[0];
+    }),
+
+  getByConductorId: publicProcedure
+    .input(z.object({ conductorId: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const { data: rows, error } = await tryCatch(
+        db
+          .select({
+            id: asignaciones.id,
+            status: asignaciones.status,
+            motivo: asignaciones.motivo,
+            fechaAsignacion: asignaciones.fechaAsignacion,
+            vehiculo: {
+              id: vehiculos.id,
+              patente: vehiculos.patente,
+              marca: vehiculos.marca,
+              modelo: vehiculos.modelo,
+              year: vehiculos.year,
+              tipo: vehiculos.tipo,
+            },
+            conductor: {
+              id: user.id,
+              name: user.name,
+              email: user.email,
+              emailVerified: user.emailVerified,
+              image: user.image,
+              role: user.role,
+            },
+          })
+          .from(asignaciones)
+          .leftJoin(vehiculos, eq(asignaciones.vehiculoId, vehiculos.id))
+          .leftJoin(user, eq(asignaciones.conductorId, user.id))
+          .where(eq(asignaciones.conductorId, input.conductorId))
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Error obteniendo asignaciones del conductor",
+        });
+      }
+      return rows;
     }),
 
   updateStatus: protectedProcedure
@@ -135,20 +186,34 @@ export const asignacionRouter = router({
       })
     )
     .mutation(async ({ input }) => {
-      const [updated] = await db
-        .update(asignaciones)
-        .set({ status: input.status })
-        .where(eq(asignaciones.id, input.id))
-        .returning();
-
-      return updated;
+      const { data: updated, error } = await tryCatch(
+        db
+          .update(asignaciones)
+          .set({ status: input.status })
+          .where(eq(asignaciones.id, input.id))
+          .returning()
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Error actualizando el estado de la asignación",
+        });
+      }
+      return updated[0];
     }),
 
   delete: protectedProcedure
     .input(z.object({ id: z.number() }))
     .mutation(async ({ input }) => {
-      await db.delete(asignaciones).where(eq(asignaciones.id, input.id));
-
+      const { error } = await tryCatch(
+        db.delete(asignaciones).where(eq(asignaciones.id, input.id))
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Error eliminando la asignación",
+        });
+      }
       return { success: true };
     }),
 });

--- a/apps/server/src/routes/asignaciones.ts
+++ b/apps/server/src/routes/asignaciones.ts
@@ -1,19 +1,4 @@
-// tryCatch helper
-type Success<T> = { data: T; error: null };
-type Failure<E> = { data: null; error: E };
-type Result<T, E = Error> = Success<T> | Failure<E>;
-
-export async function tryCatch<T, E = Error>(
-  promise: Promise<T>,
-): Promise<Result<T, E>> {
-  try {
-    const data = await promise;
-    return { data, error: null };
-  } catch (error) {
-    return { data: null, error: error as E };
-  }
-}
-
+import { tryCatch } from "../trycatch";
 import { db } from "../db/server";
 import { asignaciones } from "../db/schema";
 import { z } from "zod";

--- a/apps/server/src/routes/asignaciones.ts
+++ b/apps/server/src/routes/asignaciones.ts
@@ -14,7 +14,6 @@ export async function tryCatch<T, E = Error>(
   }
 }
 
-// --- El resto de tu router ---
 import { db } from "../db/server";
 import { asignaciones } from "../db/schema";
 import { z } from "zod";

--- a/apps/server/src/routes/asignacionesadmin.ts
+++ b/apps/server/src/routes/asignacionesadmin.ts
@@ -1,19 +1,4 @@
-
-type Success<T> = { data: T; error: null };
-type Failure<E> = { data: null; error: E };
-type Result<T, E = Error> = Success<T> | Failure<E>;
-export async function tryCatch<T, E = Error>(
-  promise: Promise<T>,
-): Promise<Result<T, E>> {
-  try {
-    const data = await promise;
-    return { data, error: null };
-  } catch (error) {
-    return { data: null, error: error as E };
-  }
-}
-
-
+import { tryCatch } from "../trycatch";
 import { z } from "zod";
 import { router } from "../trpc/core";
 import { adminProcedure } from "../trpc/procedures";

--- a/apps/server/src/routes/asignacionesadmin.ts
+++ b/apps/server/src/routes/asignacionesadmin.ts
@@ -1,3 +1,19 @@
+
+type Success<T> = { data: T; error: null };
+type Failure<E> = { data: null; error: E };
+type Result<T, E = Error> = Success<T> | Failure<E>;
+export async function tryCatch<T, E = Error>(
+  promise: Promise<T>,
+): Promise<Result<T, E>> {
+  try {
+    const data = await promise;
+    return { data, error: null };
+  } catch (error) {
+    return { data: null, error: error as E };
+  }
+}
+
+
 import { z } from "zod";
 import { router } from "../trpc/core";
 import { adminProcedure } from "../trpc/procedures";
@@ -5,6 +21,7 @@ import { asignaciones, vehiculos } from "../db/schema";
 import { db } from "../db/server";
 import { eq } from "drizzle-orm";
 import { user } from "../auth/auth-schema";
+import { TRPCError } from "@trpc/server";
 
 const asignacionSchema = z.object({
   fechaAsignacion: z.string().refine((val) => !isNaN(Date.parse(val)), {
@@ -26,35 +43,42 @@ const asignacionDeleteSchema = z.object({
 
 export const asignacionesAdminRouter = router({
   getAll: adminProcedure.query(async () => {
-    const rows = await db
-      .select({
-        id: asignaciones.id,
-        status: asignaciones.status,
-        motivo: asignaciones.motivo,
-        fechaAsignacion: asignaciones.fechaAsignacion,
-        vehiculo: {
-          id: vehiculos.id,
-          patente: vehiculos.patente,
-          marca: vehiculos.marca,
-          modelo: vehiculos.modelo,
-          year: vehiculos.year,
-          tipo: vehiculos.tipo,
-          kilometraje: vehiculos.kilometraje,
-          fueraServicio: vehiculos.fueraServicio,
-        },
-        conductor: {
-          id: user.id,
-          name: user.name,
-          email: user.email,
-          emailVerified: user.emailVerified,
-          image: user.image,
-          role: user.role,
-        },
-      })
-      .from(asignaciones)
-      .leftJoin(vehiculos, eq(asignaciones.vehiculoId, vehiculos.id))
-      .leftJoin(user, eq(asignaciones.conductorId, user.id));
-
+    const { data: rows, error } = await tryCatch(
+      db
+        .select({
+          id: asignaciones.id,
+          status: asignaciones.status,
+          motivo: asignaciones.motivo,
+          fechaAsignacion: asignaciones.fechaAsignacion,
+          vehiculo: {
+            id: vehiculos.id,
+            patente: vehiculos.patente,
+            marca: vehiculos.marca,
+            modelo: vehiculos.modelo,
+            year: vehiculos.year,
+            tipo: vehiculos.tipo,
+            kilometraje: vehiculos.kilometraje,
+            fueraServicio: vehiculos.fueraServicio,
+          },
+          conductor: {
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            emailVerified: user.emailVerified,
+            image: user.image,
+            role: user.role,
+          },
+        })
+        .from(asignaciones)
+        .leftJoin(vehiculos, eq(asignaciones.vehiculoId, vehiculos.id))
+        .leftJoin(user, eq(asignaciones.conductorId, user.id))
+    );
+    if (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Error obteniendo asignaciones",
+      });
+    }
     return rows;
   }),
 
@@ -62,13 +86,21 @@ export const asignacionesAdminRouter = router({
     .input(asignacionSchema)
     .mutation(
       async ({ input }: { input: z.infer<typeof asignacionSchema> }) => {
-        const result = await db
-          .insert(asignaciones)
-          .values({
-            ...input,
-            fechaAsignacion: new Date(input.fechaAsignacion),
-          })
-          .returning();
+        const { data: result, error } = await tryCatch(
+          db
+            .insert(asignaciones)
+            .values({
+              ...input,
+              fechaAsignacion: new Date(input.fechaAsignacion),
+            })
+            .returning()
+        );
+        if (error) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Error creando la asignación",
+          });
+        }
         return { message: "Asignación creada exitosamente", data: result[0] };
       }
     ),
@@ -78,14 +110,22 @@ export const asignacionesAdminRouter = router({
     .mutation(
       async ({ input }: { input: z.infer<typeof asignacionUpdateSchema> }) => {
         const { id, ...data } = input;
-        const result = await db
-          .update(asignaciones)
-          .set({
-            ...data,
-            fechaAsignacion: new Date(data.fechaAsignacion),
-          })
-          .where(eq(asignaciones.id, id))
-          .returning();
+        const { data: result, error } = await tryCatch(
+          db
+            .update(asignaciones)
+            .set({
+              ...data,
+              fechaAsignacion: new Date(data.fechaAsignacion),
+            })
+            .where(eq(asignaciones.id, id))
+            .returning()
+        );
+        if (error) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Error actualizando la asignación",
+          });
+        }
         return {
           message: "Asignación actualizada exitosamente",
           data: result[0],
@@ -97,7 +137,15 @@ export const asignacionesAdminRouter = router({
     .input(asignacionDeleteSchema)
     .mutation(
       async ({ input }: { input: z.infer<typeof asignacionDeleteSchema> }) => {
-        await db.delete(asignaciones).where(eq(asignaciones.id, input.id));
+        const { error } = await tryCatch(
+          db.delete(asignaciones).where(eq(asignaciones.id, input.id))
+        );
+        if (error) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Error eliminando la asignación",
+          });
+        }
         return { message: "Asignación eliminada exitosamente" };
       }
     ),

--- a/apps/server/src/routes/vehiculos.ts
+++ b/apps/server/src/routes/vehiculos.ts
@@ -1,3 +1,18 @@
+
+type Success<T> = { data: T; error: null };
+type Failure<E> = { data: null; error: E };
+type Result<T, E = Error> = Success<T> | Failure<E>;
+export async function tryCatch<T, E = Error>(
+  promise: Promise<T>,
+): Promise<Result<T, E>> {
+  try {
+    const data = await promise;
+    return { data, error: null };
+  } catch (error) {
+    return { data: null, error: error as E };
+  }
+}
+
 import { db } from "../db/server";
 import { vehiculos } from "../db/schema";
 import { z } from "zod";
@@ -15,7 +30,6 @@ const VehiculoInput = z.object({
     .min(1900)
     .max(new Date().getFullYear() + 1),
   tipo: z.string().min(3),
-  // <-- Cambio: preprocesar string→Date antes de validar
   proximoMantenimiento: z.preprocess(
     (val) => (typeof val === "string" ? new Date(val) : val),
     z.date()
@@ -27,33 +41,56 @@ const VehiculoInput = z.object({
 export const vehiculoRouter = router({
   // CREATE
   create: publicProcedure.input(VehiculoInput).mutation(async ({ input }) => {
-    const [nuevo] = await db.insert(vehiculos).values(input).returning();
-    return nuevo;
+    const { data: nuevo, error } = await tryCatch(
+      db.insert(vehiculos).values(input).returning()
+    );
+    if (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Error creando el vehículo",
+      });
+    }
+    return nuevo[0];
   }),
 
   // READ - Todos los vehículos
   getAll: publicProcedure.query(async () => {
-    return await db.select().from(vehiculos);
+    const { data: rows, error } = await tryCatch(
+      db.select().from(vehiculos)
+    );
+    if (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Error obteniendo vehículos",
+      });
+    }
+    return rows;
   }),
 
   // READ - Uno por ID
   getById: publicProcedure
     .input(z.object({ id: z.number() }))
     .query(async ({ input }) => {
-      const [vehiculo] = await db
-        .select()
-        .from(vehiculos)
-        .where(eq(vehiculos.id, input.id))
-        .limit(1);
-
-      if (!vehiculo) {
+      const { data: vehiculo, error } = await tryCatch(
+        db
+          .select()
+          .from(vehiculos)
+          .where(eq(vehiculos.id, input.id))
+          .limit(1)
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Error buscando el vehículo",
+        });
+      }
+      if (!vehiculo || vehiculo.length === 0) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Vehículo no encontrado",
         });
       }
-
-      return vehiculo;
+      return vehiculo[0];
     }),
 
   updateById: publicProcedure
@@ -64,30 +101,43 @@ export const vehiculoRouter = router({
       })
     )
     .mutation(async ({ input }) => {
-      const [actualizado] = await db
-        .update(vehiculos)
-        .set(input.data)
-        .where(eq(vehiculos.id, input.id))
-        .returning();
-
-      if (!actualizado) {
+      const { data: actualizado, error } = await tryCatch(
+        db
+          .update(vehiculos)
+          .set(input.data)
+          .where(eq(vehiculos.id, input.id))
+          .returning()
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Error actualizando el vehículo",
+        });
+      }
+      if (!actualizado || actualizado.length === 0) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Vehículo no encontrado para actualizar",
         });
       }
-
-      return actualizado;
+      return actualizado[0];
     }),
 
   deleteById: publicProcedure
     .input(z.object({ id: z.number() }))
     .mutation(async ({ input }) => {
-      await db
-        .update(vehiculos)
-        .set({ fueraServicio: true })
-        .where(eq(vehiculos.id, input.id));
-
+      const { error } = await tryCatch(
+        db
+          .update(vehiculos)
+          .set({ fueraServicio: true })
+          .where(eq(vehiculos.id, input.id))
+      );
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Error eliminando el vehículo",
+        });
+      }
       return { success: true };
     }),
 });

--- a/apps/server/src/routes/vehiculos.ts
+++ b/apps/server/src/routes/vehiculos.ts
@@ -1,18 +1,4 @@
-
-type Success<T> = { data: T; error: null };
-type Failure<E> = { data: null; error: E };
-type Result<T, E = Error> = Success<T> | Failure<E>;
-export async function tryCatch<T, E = Error>(
-  promise: Promise<T>,
-): Promise<Result<T, E>> {
-  try {
-    const data = await promise;
-    return { data, error: null };
-  } catch (error) {
-    return { data: null, error: error as E };
-  }
-}
-
+import { tryCatch } from "../trycatch";
 import { db } from "../db/server";
 import { vehiculos } from "../db/schema";
 import { z } from "zod";

--- a/apps/server/src/trycatch.ts
+++ b/apps/server/src/trycatch.ts
@@ -17,12 +17,12 @@ export type Result<T, E = Error> = Success<T> | Failure<E>;
  * @returns Un objeto con la forma { data, error }
  */
 export async function tryCatch<T, E = Error>(
-  promise: Promise<T>
+    promise: Promise<T>
 ): Promise<Result<T, E>> {
-  try {
-    const data = await promise;
-    return { data, error: null };
-  } catch (error) {
-    return { data: null, error: error as E };
-  }
+    try {
+        const data = await promise;
+        return { data, error: null };
+    } catch (error) {
+        return { data: null, error: error as E };
+    }
 }

--- a/apps/server/src/trycatch.ts
+++ b/apps/server/src/trycatch.ts
@@ -1,0 +1,28 @@
+/**
+ * Helper funcional para manejo de errores con promesas en TypeScript/JavaScript.
+ * Devuelve un resultado discriminado (success/failure) en vez de lanzar excepción.
+ *
+ * Ejemplo de uso:
+ *   const { data, error } = await tryCatch(db.query(...))
+ */
+
+export type Success<T> = { data: T; error: null };
+export type Failure<E> = { data: null; error: E };
+export type Result<T, E = Error> = Success<T> | Failure<E>;
+
+/**
+ * Ejecuta una promesa y captura cualquier error, retornando un objeto tipo Result<T, E>.
+ *
+ * @param promise - Promesa a ejecutar (por ejemplo, consulta a DB)
+ * @returns Un objeto con la forma { data, error }
+ */
+export async function tryCatch<T, E = Error>(
+  promise: Promise<T>
+): Promise<Result<T, E>> {
+  try {
+    const data = await promise;
+    return { data, error: null };
+  } catch (error) {
+    return { data: null, error: error as E };
+  }
+}


### PR DESCRIPTION
Se implementa un manejo de errores más robusto en los routers de la API utilizando el patrón tryCatch en todas las operaciones asíncronas de base de datos.

    Se capturan y controlan los posibles errores en consultas e inserciones a la base de datos, mapeando los fallos a respuestas explícitas con TRPCError para mantener una API consistente y segura.

    Se mantiene la estructura y validaciones originales, mejorando la trazabilidad de errores y facilitando la depuración tanto en desarrollo como en producción.

    El cambio aplica a los routers de asignaciones, vehículos y administración.

Esta mejora incrementa la confiabilidad del backend, entregando respuestas más claras al frontend y reduciendo posibles fallos inesperados.